### PR TITLE
Option to disable the 'drizzle' condition from Open Weather

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,7 @@ un-trip immediately if left empty
 
 ## popThreshold
 
-Current conditions from WeatherUndergound and ForecastIO contain the current
-probability of probability of precipitation. If this value is set, then pop
-values higher than the threshold will trigger the rain state.
+Current conditions from WeatherUndergound and ForecastIO contain the current probability of precipitation. If this value is set, then pop values higher than the threshold will trigger the rain state.
 
 ## windows
 
@@ -56,7 +54,7 @@ Emits when the rain stops and the optional timeout period has passed
 ## security.rain.alarm
 
 Emits a security event (same structure as the SecurityZone module events)
-when rain starts while an open window was detectet
+when rain starts while an open window was detected
 
 # Virtual Devices
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 /*** Rain Z-Way HA module *******************************************
 
-Version: 1.09
+Version: 1.10
 (c) Maroš Kollár, 2015-2017
 -----------------------------------------------------------------------------
 Author: Maroš Kollár <maros@k-1.com>
@@ -289,7 +289,21 @@ Rain.prototype.checkRain = function(trigger) {
     if (typeof(self.openWeather) !== 'undefined') {
         condition = self.openWeather.get('metrics:zwaveOpenWeather');
         // see http://openweathermap.org/weather-conditions
-        if (_.contains([
+        if (self.openWeatherDrizzleDisabled) {
+            if (_.contains([
+                200, 201, 202, 210, 211, 212, 221, 230, 231, 232,
+                500, 501, 502, 503, 504, 511, 520, 521, 522, 531,
+                600, 601, 602, 611, 612, 615, 616, 620, 621, 622,
+                771,
+                901, 902, 906, 960, 961, 962
+            ],condition.weather[0].id)) {
+            self.log('Detected rain from OpenWeather');
+            rain = true;
+            sources.push(self.openWeather.id+'/metrics:zwaveOpenWeather:condition:weather:0:id');
+            }
+        }
+        else {
+            if (_.contains([
                 200, 201, 202, 210, 211, 212, 221, 230, 231, 232,
                 300, 301, 302, 310, 311, 312, 313, 314, 321,
                 500, 501, 502, 503, 504, 511, 520, 521, 522, 531,
@@ -300,6 +314,7 @@ Rain.prototype.checkRain = function(trigger) {
             self.log('Detected rain from OpenWeather');
             rain = true;
             sources.push(self.openWeather.id+'/metrics:zwaveOpenWeather:condition:weather:0:id');
+            }
         }
     }
 

--- a/lang/de.json
+++ b/lang/de.json
@@ -3,6 +3,8 @@
    "intensity_threshold_label" : "Regenitensität Schwellenwert",
    "m_descr" : "Dieses Modul prüft die Wetterbedingungen (mit OpenWeather, ForecastIO, WeatherUnderground oder Unwetterwarnungs Modulen) und optional binären Sensoren um Regen zu melden.<br>Siehe <a href=https://github.com/maros/Zway-Rain/blob/master/README.md>github.com/maros/Zway-Rain</a> für detailliertere Dokumentation.",
    "m_title" : "Virtueller Regensensor",
+   "open_weather_drizzle_helper" : "Check the box to disable the 'drizzle' group of conditions.  See http://openweathermap.org/weather-conditions for descriptions.",
+   "open_weather_drizzle_label" : "Disable Open Weather 'drizzle' conditions",
    "pop_threshold_helper" : "Setzt den Schwellenwert für die Vorhersage der Regenwarscheinlichkeit. Regensensor löst aus, wenn der Grenzwert überschritten wird.",
    "pop_threshold_label" : "Regenwahrscheinlichkeit Schwellenwert",
    "rain_sensor_poll_helper" : "Maximales abfrage Intervall für die Regensensoren in Sekunden. Je höher die Regenwarscheinlichkeit desto kürzer das Intervall.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -3,6 +3,8 @@
    "intensity_threshold_label" : "Rain intensity threshold",
    "m_descr" : "This module checks weather conditions (via the OpenWeather, ForecastIO, WeatherUnderground or Weather Alert modules) and optional binary sensors to detect rain.<br>Check <a href=https://github.com/maros/Zway-Rain/blob/master/README.md>github.com/maros/Zway-Rain</a> for detailed documentation.",
    "m_title" : "Virtual Rain Sensor",
+   "open_weather_drizzle_helper" : "Check the box to disable the 'drizzle' group of conditions.  See http://openweathermap.org/weather-conditions for descriptions.",
+   "open_weather_drizzle_label" : "Disable Open Weather 'drizzle' conditions",
    "pop_threshold_helper" : "Sets the threshold for rain probability forecasts. Rain sensor will be triggered if threshold is exceeded.",
    "pop_threshold_label" : "Probability of rain threshold",
    "rain_sensor_poll_helper" : "Maximum poll interval for rain sensors in seconds. Actual poll interval will be shorther the higher the rain probability",

--- a/module.json
+++ b/module.json
@@ -5,6 +5,7 @@
       "description" : "__m_descr__",
       "intensityThreshold" : 0,
       "popThreshold" : 0,
+      "openWeatherDrizzleDisabled" : false,
       "rainSensorPoll" : 0,
       "rainSensors" : [],
       "title" : "__m_title__",
@@ -29,10 +30,15 @@
             "label" : "__pop_threshold_label__",
             "order" : 2
          },
+         "openWeatherDrizzleDisabled" : {
+            "helper" : "__open_weather_drizzle_helper__",
+            "label" : "__open_weather_drizzle_label__",
+            "order" : 4
+         },         
          "rainSensorPoll" : {
             "helper" : "__rain_sensor_poll_helper__",
             "label" : "__rain_sensor_poll_label__",
-            "order" : 5
+            "order" : 6
          },
          "rainSensors" : {
             "fields" : {
@@ -45,7 +51,7 @@
             },
             "helper" : "__rain_sensors_helper__",
             "label" : "__rain_sensors_label__",
-            "order" : 4
+            "order" : 5
          },
          "timeout" : {
             "helper" : "__timeout_helper__",
@@ -63,7 +69,7 @@
             },
             "helper" : "__windows_helper__",
             "label" : "__windows_label__",
-            "order" : 6
+            "order" : 7
          }
       }
    },
@@ -78,6 +84,9 @@
          },
          "popThreshold" : {
             "type" : "integer"
+         },
+         "openWeatherDrizzleDisabled" : {
+            "type" : "boolean"
          },
          "rainSensorPoll" : {
             "type" : "number"
@@ -110,5 +119,5 @@
       "type" : "object"
    },
    "singleton" : true,
-   "version" : "1.09"
+   "version" : "1.10"
 }


### PR DESCRIPTION
Added ability to disable the 'drizzle' condition from Open Weather.  I'm getting a ton of false positive Rain conditions from it.

Also fixed a few typos in the readme

Need help with the German translation for the label.